### PR TITLE
Added parsed xhr response as second arg to callbacks

### DIFF
--- a/xapiwrapper.js
+++ b/xapiwrapper.js
@@ -1032,7 +1032,18 @@ if ( !Date.prototype.toISOString ) {
                 var notFoundOk = (ignore404 && xhr.status === 404);
                 if (xhr.status === undefined || (xhr.status >= 200 && xhr.status < 400) || notFoundOk) {
                     if (callback) {
-                        callback(xhr, callbackargs);
+                        if(callbackargs){
+                            callback(xhr, callbackargs);
+                        }
+                        else {
+                            try {
+                                var body = JSON.parse(xhr.responseText);
+                                callback(xhr,body);
+                            }
+                            catch(e){
+                                callback(xhr,xhr.responseText);
+                            }
+                        }
                     } else {
                         result = xhr;
                         return xhr;


### PR DESCRIPTION
In my experience, the first line of every single callback tends to be something to the effect of `body = JSON.parse(xhr.response);`, so I added the parsed response as an argument to the callback. Seems like a logical choice, and doesn't break legacy code.
