### PR TITLE
Recommend that a "callback" function is still called on XHR fail

### DIFF
--- a/xapiwrapper.js
+++ b/xapiwrapper.js
@@ -1062,14 +1062,15 @@ function toSHA1(text){
                         return xhr;
                     }
                 } else {
+                    var warning;
                     try {
-                        console.warn("There was a problem communicating with the Learning Record Store. ( " 
-                            + xhr.status + " | " + xhr.response+ " )" + url);
-                            ADL.xhrRequestOnError(xhr, method, url);
+                        warning = "There was a problem communicating with the Learning Record Store. ( " 
+                            + xhr.status + " | " + xhr.response+ " )" + url
                     } catch (ex) {
-                        console.warn(ex.toString());
-                        ADL.xhrRequestOnError(xhr, method, url);
+                        warning = ex.toString();
                     }
+                    console.warn(warning);
+                    ADL.xhrRequestOnError(xhr, method, url, callback, callbackargs);
                     //throw new Error("debugger");
                     result = xhr;
                     return xhr;
@@ -1110,7 +1111,7 @@ function toSHA1(text){
      * method - XMLHttpRequest request method
      * url - full endpoint url
      */
-    ADL.xhrRequestOnError = function(xhr, method, url){};
+    ADL.xhrRequestOnError = function(xhr, method, url, callback, callbackargs){};
 
     ADL.XAPIWrapper = new XAPIWrapper(Config, false);
 


### PR DESCRIPTION
I would like to propose that a defined "callback" function is still called even when an XHR Request fails, or at the very least, the callback and callbackargs are passed as arguments to xhrRequestOnError to allow access to these.

I would expect my callback function to still run when receiving a "401" when attempting to authenticate a user. I don't consider this a fatal error and would therefore expect my callback function to execute, so that I can handle the "401"

The way I have implemented in the script allows developers to "hook" into xhrRequestOnError and do with it what they want and provide access to callback.