### PR TITLE
Fix parseQueryString

### DIFF
--- a/src/xapiwrapper.js
+++ b/src/xapiwrapper.js
@@ -1167,18 +1167,16 @@ function isDate(date) {
     // parses the params in the url query string
     function parseQueryString()
     {
-        var loc, qs, pairs, pair, ii, parsed;
+        var qs, pairs, pair, ii, parsed;
 
-        loc = window.location.href.split('?');
-        if (loc.length === 2) {
-            qs = loc[1];
-            pairs = qs.split('&');
-            parsed = {};
-            for ( ii = 0; ii < pairs.length; ii++) {
-                pair = pairs[ii].split('=');
-                if (pair.length === 2 && pair[0]) {
-                    parsed[pair[0]] = decodeURIComponent(pair[1]);
-                }
+        qs = window.location.search.substr(1);
+
+        pairs = qs.split('&');
+        parsed = {};
+        for ( ii = 0; ii < pairs.length; ii++) {
+            pair = pairs[ii].split('=');
+            if (pair.length === 2 && pair[0]) {
+                parsed[pair[0]] = decodeURIComponent(pair[1]);
             }
         }
 


### PR DESCRIPTION
The parseQueryString method in xAPIWrapper takes no account of hashes potentially appearing after the search paramters.

As per issue #74 