### PR TITLE
Resolves #89 and partially resolves #97

### DIFF
--- a/src/xapiwrapper.js
+++ b/src/xapiwrapper.js
@@ -143,7 +143,9 @@ function isDate(date) {
         this.base = getbase(this.lrs.endpoint);
 
         this.withCredentials = false;
-        this.withCredentials = config && config.withCredentials;
+        if (config && typeof(config.withCredentials) != 'undefined') {
+            this.withCredentials = config.withCredentials;
+        }
 
         // Ensure that callbacks are always executed, first param is error (null if no error) followed
         // by the result(s)
@@ -154,10 +156,15 @@ function isDate(date) {
         {
             var l = document.createElement("a");
             l.href = url;
-            if (l.protocol && l.host)
+            if (l.protocol && l.host) {
                 return l.protocol + "//" + l.host;
+            } else if (l.href) {
+                // IE 11 fix.
+                var parts = l.href.split("//");
+                return parts[0] + "//" + parts[1].substr(0, parts[1].indexOf("/"));
+            }
             else
-                ADL.XAPIWrapper.log("Couldn't create base url from endpoint: " + this.lrs.endpoint);
+                ADL.XAPIWrapper.log("Couldn't create base url from endpoint: " + url);
         }
 
         function updateAuth(obj, username, password){


### PR DESCRIPTION
Note that #97 still requires some kind of shim for the URL object in IE, but this commit contains two fixes for IE 11, even with the shim in place.
- The 'withCredentials' property could be set to undefined and caused the code to error, but a typeof check corrects this (thanks @shigil)
- The getbase() errored with xAPI launch because 'protocol' and 'port' were undefined