### PR TITLE
Resolves #115, corrects issue with contentType hard-coding

### DIFF
--- a/src/xapiwrapper.js
+++ b/src/xapiwrapper.js
@@ -400,7 +400,7 @@ function isDate(date) {
         {
             if (attachments.hasOwnProperty(i))
             {
-                body += CRLF + '--' + boundary + CRLF + 'X-Experience-API-Hash:' + attachments[i].type.sha2 + CRLF + "Content-Type:application/octet-stream" + CRLF + "Content-Transfer-Encoding: binary" + CRLF + CRLF
+                body += CRLF + '--' + boundary + CRLF + 'X-Experience-API-Hash:' + attachments[i].type.sha2 + CRLF + "Content-Type:" + attachments[i].type.contentType + CRLF + "Content-Transfer-Encoding: binary" + CRLF + CRLF
                 body += attachments[i].value;
             }
         }


### PR DESCRIPTION
This now takes it from the contentType on an attachment array item.