### PR TITLE
Resolves #117, adds proper support for binary attachments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
       'build': {
         files: {
           'dist/xapiwrapper.min.js': [
+            'node_modules/text-encoding/lib/encoding.js',
             'lib/cryptojs_v3.1.2.js',
             'src/activitytypes.js',
             'src/verbs.js',

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-exec": "~0.4.6",
     "doxstrap": "~0.0.5"
+  },
+  "dependencies": {
+    "text-encoding": "^0.7.0"
   }
 }


### PR DESCRIPTION
This corrects the issue with binary file corruption and incorrect SHA2 values.

It does this by accepting attachments as an Array Buffer and transmitting them as a multipart 'binary' transfer.

The 'text-encoding' package has been added for IE support.