### PR TITLE
Generate source map

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,8 @@ module.exports = function(grunt) {
     },
     'uglify': {
       options: {
-        banner: '/*! <%= pkg.name %> v <%= pkg.version %> | Built on <%= grunt.template.today("yyyy-mm-dd HH:MM:sso") %> */\n'
+        banner: '/*! <%= pkg.name %> v <%= pkg.version %> | Built on <%= grunt.template.today("yyyy-mm-dd HH:MM:sso") %> */\n',
+        sourceMap: true
       },
       'build': {
         files: {


### PR DESCRIPTION
This adds source map generation to the build process. This depends on #156 which upgrades Grunt.